### PR TITLE
Modify the way to get group ID

### DIFF
--- a/src/main/java/org/fisco/bcos/autoconfigure/ServiceConfig.java
+++ b/src/main/java/org/fisco/bcos/autoconfigure/ServiceConfig.java
@@ -16,7 +16,7 @@ import org.springframework.context.annotation.Configuration;
 public class ServiceConfig {
 
     private String agencyName;
-    private static int groupId = 1;
+    private int groupId;
 
     @Bean
     public Service getService(GroupChannelConnectionsConfig groupChannelConnectionsConfig) {


### PR DESCRIPTION
修改[ServiceConfig](https://github.com/FISCO-BCOS/spring-boot-starter/blob/master/src/main/java/org/fisco/bcos/autoconfigure/ServiceConfig.java)中获取groupId的方式，现在的groupId是static固定为1，没有从[application.yml](https://github.com/FISCO-BCOS/spring-boot-starter/blob/master/src/main/resources/application.yml)里面动态获取。